### PR TITLE
3.6 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,11 +29,11 @@
         "preferred-install": "src"
     },
     "require": {
-        "php": ">=5.4.16",
-        "cakephp/cakephp": "~3.0"
+        "php": ">=5.6",
+        "cakephp/cakephp": "~3.6"
     },
     "require-dev": {
-        "phpunit/phpunit": "*"
+        "phpunit/phpunit": "^5.7.14|^6.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Dialect/FirebirdDialectTrait.php
+++ b/src/Dialect/FirebirdDialectTrait.php
@@ -90,7 +90,7 @@ trait FirebirdDialectTrait
     protected function _insertQueryTranslator($query)
     {
         $v = $query->clause('values');
-        if (count($v->values()) === 1 || $v->query()) {
+        if (count($v->getValues()) === 1 || $v->query()) {
             return $query;
         }
 
@@ -99,7 +99,7 @@ trait FirebirdDialectTrait
         $placeholder = 0;
         $replaceQuery = false;
 
-        foreach ($v->values() as $k => $val) {
+        foreach ($v->getValues() as $k => $val) {
             $fillLength = count($cols) - count($val);
             if ($fillLength > 0) {
                 $val = array_merge($val, array_fill(0, $fillLength, null));

--- a/src/FirebirdCompiler.php
+++ b/src/FirebirdCompiler.php
@@ -51,7 +51,7 @@ class FirebirdCompiler extends QueryCompiler
      */
     protected function _buildSelectPart($parts, $query, $generator)
     {
-        $driver = $query->connection()->driver();
+        $driver = $query->getConnection()->getDriver();
         $select = 'SELECT %s%s%s';
         if ($this->_orderedUnion && $query->clause('union')) {
             $select = '(SELECT %s%s%s';

--- a/src/FirebirdCompiler.php
+++ b/src/FirebirdCompiler.php
@@ -51,7 +51,9 @@ class FirebirdCompiler extends QueryCompiler
      */
     protected function _buildSelectPart($parts, $query, $generator)
     {
-        $driver = $query->getConnection()->getDriver();
+        $driver = $query
+            ->getConnection()
+            ->getDriver();
         $select = 'SELECT %s%s%s';
         if ($this->_orderedUnion && $query->clause('union')) {
             $select = '(SELECT %s%s%s';

--- a/src/Schema/FirebirdSchema.php
+++ b/src/Schema/FirebirdSchema.php
@@ -285,7 +285,7 @@ class FirebirdSchema extends BaseSchema
      */
     public function columnSql(Table $table, $name)
     {
-        $data = $table->column($name);
+        $data = $table->getColumn($name);
         $out = $this->_driver->quoteIdentifier($name);
         $typeMap = [
             'integer' => ' INTEGER',
@@ -380,7 +380,7 @@ class FirebirdSchema extends BaseSchema
      */
     public function constraintSql(Table $table, $name)
     {
-        $data = $table->constraint($name);
+        $data = $table->getConstraint($name);
         if ($data['type'] === Table::CONSTRAINT_PRIMARY) {
             return sprintf('CONSTRAINT pk_%s_0 PRIMARY KEY ("%s")', $table->name(), implode(', ', $data['columns']));
         }

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -70,7 +70,7 @@ class QueryTest extends TestCase
     {
         $query = $this->Articles->find('all');
         $this->assertInstanceOf('Cake\ORM\Query', $query);
-        $result = $query->hydrate(false)->toArray();
+        $result = $query->enableHydration(false)->toArray();
         $expected = [
             ['id' => 1, 'author_id' => 1, 'title' => 'First Article', 'body' => 'First Article Body', 'published' => 'Y'],
         ];


### PR DESCRIPTION
I removed deprecated method calls

I also changed the minimal requirements to PHP 5.6 and cakephp 3.6

I moved PHPUnit back to 6 (aligned with cakephp composer.json)